### PR TITLE
Create README for canva-sdks organization

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,7 +1,22 @@
-# 👋 Welcome to Canva!
+# canva-sdks
 
-This GitHub organization contains our [Apps SDK starter kit](https://github.com/canva-sdks/canva-apps-sdk-starter-kit) for Canva's app development platform. 🎉
+Hello there. 👋
 
-The complete documentation for the platform can be found at https://canva.dev/docs/apps
+This GitHub organization contains repos for Canva's developer platform.
 
+## Getting started
 
+- To discover what's possible with Canva's developer platform, see [canva.com/developers](https://www.canva.com/developers).
+- To learn how to start building with Canva's SDK and APIs, read the documentation at [canva.dev](https://www.canva.dev).
+- To chat with Canva's growing developer community, check out [community.canva.dev](https://community.canva.dev).
+
+## Developer support
+
+If you have any questions, feedback, or requests related to Canva's developer platform, either:
+
+- Submit a support ticket via [our helpdesk](https://canvadev.atlassian.net/servicedesk/customer/portal/8)
+- Post a thread in the [Canva Developers Community](https://community.canva.dev)
+
+## Contributing
+
+We're not currently accepting third-party contributions for any our repos. If you'd like to request changes or additions, submit a request via the [Canva Developers Community](https://community.canva.dev).


### PR DESCRIPTION
This PR adds a little more information to the README for the `canva-sdks` organization, such as resources to learn more about Canva's developer platform and links for getting support.