### PR TITLE
Some minor fixes for the README

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -4,7 +4,7 @@ Hello there. 👋
 
 This GitHub organization contains repos for Canva's developer platform.
 
-## Quick start
+## First steps
 
 - To discover what's possible with Canva's developer platform, see [canva.com/developers](https://www.canva.com/developers).
 - To learn how to start building with Canva's SDKs and APIs, read the documentation at [canva.dev](https://www.canva.dev).

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,13 +1,13 @@
-# canva-sdks
+## Introduction
 
 Hello there. 👋
 
 This GitHub organization contains repos for Canva's developer platform.
 
-## Getting started
+## Quick start
 
 - To discover what's possible with Canva's developer platform, see [canva.com/developers](https://www.canva.com/developers).
-- To learn how to start building with Canva's SDK and APIs, read the documentation at [canva.dev](https://www.canva.dev).
+- To learn how to start building with Canva's SDKs and APIs, read the documentation at [canva.dev](https://www.canva.dev).
 - To chat with Canva's growing developer community, check out [community.canva.dev](https://community.canva.dev).
 
 ## Developer support


### PR DESCRIPTION
This PR makes some minor fixes to the README:

- Removes the `h1`, since the organization home page already has a `h1`
- Adds an **Introduction** heading
- Renames "Getting started" to "First steps"
- Pluralizes "SDK" to account for the possibility of multiple SDKs